### PR TITLE
Added SetStyleFlag/SetExStyleFlag to toggle flags on/off and only update them if changed

### DIFF
--- a/WinWrapper/Window.Properties.Styles.cs
+++ b/WinWrapper/Window.Properties.Styles.cs
@@ -17,10 +17,30 @@ partial struct Window
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _ = PInvoke.SetWindowLongPtr(Handle, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (nint)value);
     }
-    /// <summary>
-    /// Get or set the Extended Style of the <see cref="Window"/>
-    /// </summary>
-    public WINDOW_EX_STYLE ExStyle
+	public void SetStyleFlag(WINDOW_STYLE style, bool enabled) {
+		var curStyle = Style;
+		var origStyle = curStyle;
+		if (enabled)
+			curStyle |= style;
+		else
+			curStyle &= ~style;
+		if (curStyle != origStyle)
+			Style = curStyle;
+	}
+	public void SetExStyleFlag(WINDOW_EX_STYLE style, bool enabled) {
+		var curStyle = ExStyle;
+		var origStyle = curStyle;
+		if (enabled)
+			curStyle |= style;
+		else
+			curStyle &= ~style;
+		if (curStyle != origStyle)
+			ExStyle = curStyle;
+	}
+	/// <summary>
+	/// Get or set the Extended Style of the <see cref="Window"/>
+	/// </summary>
+	public WINDOW_EX_STYLE ExStyle
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => (WINDOW_EX_STYLE)GetWindowLong(WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);

--- a/WinWrapper/Window.Properties.StylesWrapper.cs
+++ b/WinWrapper/Window.Properties.StylesWrapper.cs
@@ -12,14 +12,9 @@ partial struct Window
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => (Style & WINDOW_STYLE.WS_SIZEBOX) != 0;
 
-        set
-        {
-            if (value)
-                Style |= WINDOW_STYLE.WS_SIZEBOX;
-            else
-                Style &= ~WINDOW_STYLE.WS_SIZEBOX;
-        }
-    }
+		set => SetStyleFlag(WINDOW_STYLE.WS_SIZEBOX, value);
+
+	}
     //public bool IsVisibleStyle
     //{
     //    get => (Style & WINDOW_STYLE.WS_VISIBLE) != 0;
@@ -40,12 +35,6 @@ partial struct Window
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => (Style & WINDOW_STYLE.WS_CAPTION) != 0;
 
-        set
-        {
-            if (value)
-                Style |= WINDOW_STYLE.WS_CAPTION;
-            else
-                Style &= ~WINDOW_STYLE.WS_CAPTION;
-        }
+        set => SetStyleFlag(WINDOW_STYLE.WS_CAPTION, value);
     }
 }


### PR DESCRIPTION
Switched IsVisible and IsResizable to use them

This should drastically reduce the PInvoke set calls to only fire on changes.  I haven't found cases where the getter is stale.  As it was already getting the Style before with the two set helpers this only reduces calls and users can still manually set Style to fire it without fetching first.