### PR TITLE
Preview tooling for better build caching and CLI builds.

### DIFF
--- a/WinWrapper/WinWrapper.csproj
+++ b/WinWrapper/WinWrapper.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-windows10.0.22621.0</TargetFrameworks>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
WinUI dotnet cli building for libs is a bit broken ( https://github.com/dotnet/maui/issues/5886 ) this fixes that. This also fixes the issue that some of the xaml libs (ie cubeui) were rebuilding on every build even if not modified.  Cuts my build time by about half.